### PR TITLE
Integrate riscv-tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/riscv-tests"]
+	path = tests/riscv-tests
+	url = https://github.com/riscv-software-src/riscv-tests

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,34 @@ CC ?= gcc
 CFLAGS = -O2 -Wall
 LDFLAGS = -lpthread
 
-all:
-	$(CC) $(CFLAGS) -o semu semu.c $(LDFLAGS)
+# For compiling riscv-tests
+CROSS_COMPILE ?= riscv64-unknown-elf-
+
+CUR_DIR := $(shell pwd)
+TESTS_DIR := $(CUR_DIR)/tests
+RISCV_TESTS_DIR := $(TESTS_DIR)/riscv-tests
+RISCV_TESTS_TARGET_DIR := $(RISCV_TESTS_DIR)/target
+RISCV_TESTS_SUITE_DIR := $(RISCV_TESTS_TARGET_DIR)/share/riscv-tests/isa
+RISCV_TESTS_BIN_DIR := $(TESTS_DIR)/riscv-tests-data
+
+BIN := semu
+
+OBJS := semu.o
+
+# Whether to enable riscv-tests
+ENABLE_RISCV_TESTS ?= 0
+ifeq ("$(ENABLE_RISCV_TESTS)", "1")
+CFLAGS += -DENABLE_RISCV_TESTS
+OBJS += tests/isa-test.o
+endif
+
+%.o: %.c
+	$(CC) -o $@ $(CFLAGS) -c $<
+
+all: $(BIN)
+
+$(BIN): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 kernel.bin:
 	scripts/download.sh
@@ -11,7 +37,31 @@ kernel.bin:
 check: all kernel.bin
 	./semu kernel.bin fs.img
 
+tests/riscv-tests/configure:
+	git submodule update --init --recursive
+
+# Fetch and build riscv-tests project
+# Transform the original elf format to binary format
+build-riscv-tests: tests/riscv-tests/configure
+	cd $(RISCV_TESTS_DIR); autoconf; ./configure --prefix=$(RISCV_TESTS_TARGET_DIR)
+	$(MAKE) -C $(RISCV_TESTS_DIR)
+	$(MAKE) -C $(RISCV_TESTS_DIR) install
+	mkdir -p $(RISCV_TESTS_BIN_DIR)
+	for file in $(RISCV_TESTS_SUITE_DIR)/rv64*; do \
+		case $$file in \
+			(*.dump) continue; \
+		esac; \
+		original=$$(basename $$file); \
+		filename=$$(echo $$original | sed -e "s/-/_/g"); \
+		$(CROSS_COMPILE)objcopy -O binary $$file $(RISCV_TESTS_BIN_DIR)/$$filename; \
+		echo $$file "--> $(RISCV_TESTS_BIN_DIR)/$$filename"; \
+	done
+
+riscv-tests: $(BIN) build-riscv-tests
+	./semu --test
+
 clean:
-	rm -f semu
+	rm -f $(BIN) $(OBJS)
 distclean: clean
 	rm -f kernel.bin fs.img
+	rm -rf $(RISCV_TESTS_BIN_DIR)

--- a/tests/isa-test.c
+++ b/tests/isa-test.c
@@ -1,0 +1,104 @@
+#include <stdio.h>
+
+#include "test.h"
+
+struct testdata riscv_tests[] = {
+    /* rv64ui-p-* */
+    ADD_INSN_TEST(rv64ui_p_add),
+    ADD_INSN_TEST(rv64ui_p_addi),
+    ADD_INSN_TEST(rv64ui_p_addi),
+    ADD_INSN_TEST(rv64ui_p_addiw),
+    ADD_INSN_TEST(rv64ui_p_addw),
+    ADD_INSN_TEST(rv64ui_p_and),
+    ADD_INSN_TEST(rv64ui_p_andi),
+    ADD_INSN_TEST(rv64ui_p_auipc),
+    ADD_INSN_TEST(rv64ui_p_beq),
+    ADD_INSN_TEST(rv64ui_p_bge),
+    ADD_INSN_TEST(rv64ui_p_bgeu),
+    ADD_INSN_TEST(rv64ui_p_blt),
+    ADD_INSN_TEST(rv64ui_p_bltu),
+    ADD_INSN_TEST(rv64ui_p_bne),
+    ADD_INSN_TEST(rv64ui_p_fence_i),
+    ADD_INSN_TEST(rv64ui_p_jal),
+    ADD_INSN_TEST(rv64ui_p_jalr),
+    ADD_INSN_TEST(rv64ui_p_lb),
+    ADD_INSN_TEST(rv64ui_p_lbu),
+    ADD_INSN_TEST(rv64ui_p_ld),
+    ADD_INSN_TEST(rv64ui_p_lh),
+    ADD_INSN_TEST(rv64ui_p_lhu),
+    ADD_INSN_TEST(rv64ui_p_lui),
+    ADD_INSN_TEST(rv64ui_p_lw),
+    ADD_INSN_TEST(rv64ui_p_lwu),
+    ADD_INSN_TEST(rv64ui_p_or),
+    ADD_INSN_TEST(rv64ui_p_ori),
+    ADD_INSN_TEST(rv64ui_p_sb),
+    ADD_INSN_TEST(rv64ui_p_sd),
+    ADD_INSN_TEST(rv64ui_p_sh),
+    ADD_INSN_TEST(rv64ui_p_simple),
+    ADD_INSN_TEST(rv64ui_p_sll),
+    ADD_INSN_TEST(rv64ui_p_slli),
+    ADD_INSN_TEST(rv64ui_p_slliw),
+    ADD_INSN_TEST(rv64ui_p_sllw),
+    ADD_INSN_TEST(rv64ui_p_slt),
+    ADD_INSN_TEST(rv64ui_p_slti),
+    ADD_INSN_TEST(rv64ui_p_sltiu),
+    ADD_INSN_TEST(rv64ui_p_sltu),
+    ADD_INSN_TEST(rv64ui_p_sra),
+    ADD_INSN_TEST(rv64ui_p_srai),
+    ADD_INSN_TEST(rv64ui_p_sraiw),
+    ADD_INSN_TEST(rv64ui_p_sraw),
+    ADD_INSN_TEST(rv64ui_p_srl),
+    ADD_INSN_TEST(rv64ui_p_srli),
+    ADD_INSN_TEST(rv64ui_p_srliw),
+    ADD_INSN_TEST(rv64ui_p_srlw),
+    ADD_INSN_TEST(rv64ui_p_sub),
+    ADD_INSN_TEST(rv64ui_p_subw),
+    ADD_INSN_TEST(rv64ui_p_sw),
+    ADD_INSN_TEST(rv64ui_p_xor),
+    ADD_INSN_TEST(rv64ui_p_xori),
+
+    /* rv64ua-p-* */
+    ADD_INSN_TEST(rv64ua_p_amoadd_d),
+    ADD_INSN_TEST(rv64ua_p_amoadd_w),
+    ADD_INSN_TEST(rv64ua_p_amoand_d),
+    ADD_INSN_TEST(rv64ua_p_amoand_w),
+    ADD_INSN_TEST(rv64ua_p_amomax_d),
+    ADD_INSN_TEST(rv64ua_p_amomax_w),
+    ADD_INSN_TEST(rv64ua_p_amomaxu_d),
+    ADD_INSN_TEST(rv64ua_p_amomaxu_w),
+    ADD_INSN_TEST(rv64ua_p_amomin_d),
+    ADD_INSN_TEST(rv64ua_p_amomin_w),
+    ADD_INSN_TEST(rv64ua_p_amominu_d),
+    ADD_INSN_TEST(rv64ua_p_amominu_w),
+    ADD_INSN_TEST(rv64ua_p_amoor_d),
+    ADD_INSN_TEST(rv64ua_p_amoor_w),
+    ADD_INSN_TEST(rv64ua_p_amoswap_d),
+    ADD_INSN_TEST(rv64ua_p_amoswap_w),
+    ADD_INSN_TEST(rv64ua_p_amoxor_d),
+    ADD_INSN_TEST(rv64ua_p_amoxor_w),
+    ADD_INSN_TEST(rv64ua_p_lrsc),
+};
+
+const int n_riscv_tests = sizeof(riscv_tests) / sizeof(struct testdata);
+
+#define C_RST "\033[0m"   /* RESET */
+#define C_DR "\033[0;31m" /* Dark Red */
+#define C_DG "\033[0;32m" /* Dark Green */
+
+void print_test_result(void)
+{
+    int pass = 0;
+
+    for (int n = 0; n < n_riscv_tests; n++) {
+        if (riscv_tests[n].result != TEST_PASS) {
+            printf(C_DR "Fail: %s" C_RST "\n", riscv_tests[n].name);
+        } else {
+            printf(C_DG "Pass: %s" C_RST "\n", riscv_tests[n].name);
+            pass++;
+        }
+    }
+
+    puts("\n=======================");
+    printf("Test result: %d/%d\n", pass, n_riscv_tests);
+    puts("=======================");
+}

--- a/tests/test.h
+++ b/tests/test.h
@@ -1,0 +1,24 @@
+#ifndef __TEST_H__
+#define __TEST_H__
+
+#define TEST_PASS 0
+#define TEST_FAIL -1
+
+struct testdata {
+    int result;
+    const char *name;
+    const char *file_path;
+};
+
+#define ADD_INSN_TEST(op)                           \
+    {                                               \
+        .result = TEST_FAIL, .name = #op,           \
+        .file_path = "tests/riscv-tests-data/" #op, \
+    }
+
+extern struct testdata riscv_tests[];
+extern const int n_riscv_tests;
+
+void print_test_result(void);
+
+#endif


### PR DESCRIPTION
As the discussion in the issue ticket.
This patch first supports **./semu  --test** command to run all test binaries and show the test result like:

```
$ make test
cc -O2 -Wall -Iinclude -o semu semu.c test/test.c -lpthread
./semu --test
Test binary rv64ui_p_fence_i failed...
An exception occurred.
Test binary rv64ua_p_amoadd_w failed...
Fail test case = 2.
Test binary rv64ua_p_amoand_d failed...
An exception occurred.
Pass: rv64ui_p_add
Pass: rv64ui_p_addi
Pass: rv64ui_p_addiw
Pass: rv64ui_p_addw
Pass: rv64ui_p_and
Pass: rv64ui_p_andi
Pass: rv64ui_p_auipc
Fail: rv64ui_p_fence_i
...
Pass: rv64ui_p_jal
...
Pass: rv64ua_p_amoadd_d
Fail: rv64ua_p_amoadd_w
Fail: rv64ua_p_amoand_d
=======================
Test result: 51/54
=======================
```

A new entry point is declared to execute test flow.
And a new C file **./test/test.c** and related header are created for information of test binaries.
Note that I just put parts of the test binaires into this patch.

I think there are many spaces to optimize this patch.
Please review this patch and give some advices, thanks.

