### PR TITLE
Make use of 'curl' in macOS

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -10,11 +10,7 @@ ROOTFS_CHECKSUM=27fd366b4383f1176f44095fa270d23e9b3f4deb
 
 echo "Downloading..."
 
-if [[ $OSTYPE == 'darwin'* ]]; then
-	DOWNLOAD_CMD="curl -s -O -L -C -"
-else
-	DOWNLOAD_CMD="wget -q -c"
-fi
+DOWNLOAD_CMD="curl -s -O -L -C -"
 
 $DOWNLOAD_CMD $BASE_URL/kernel.bin || exit 1
 echo "${KERNEL_CHECKSUM}  kernel.bin" | shasum -c || exit 1

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -10,8 +10,14 @@ ROOTFS_CHECKSUM=27fd366b4383f1176f44095fa270d23e9b3f4deb
 
 echo "Downloading..."
 
-wget -q -c $BASE_URL/kernel.bin || exit 1
+if [[ $OSTYPE == 'darwin'* ]]; then
+	DOWNLOAD_CMD="curl -s -O -L -C -"
+else
+	DOWNLOAD_CMD="wget -q -c"
+fi
+
+$DOWNLOAD_CMD $BASE_URL/kernel.bin || exit 1
 echo "${KERNEL_CHECKSUM}  kernel.bin" | shasum -c || exit 1
 
-wget -q -c $BASE_URL/fs.img || exit 1
+$DOWNLOAD_CMD $BASE_URL/fs.img || exit 1
 echo "${ROOTFS_CHECKSUM}  fs.img" | shasum -c || exit 1


### PR DESCRIPTION
### Note to reviewers
 - Make download script work on macOS where `curl` is installed by default.
 - Thank you for making this emulator :)

### Tests
 - On my Mac (macOS Monterey 12.4):
```Shell
➜  semu git:(master) ✗ make distclean check
rm -f semu
rm -f kernel.bin fs.img
cc -O2 -Wall -o semu semu.c -lpthread
scripts/download.sh
Downloading...
kernel.bin: OK
fs.img: OK
./semu kernel.bin fs.img

xv6 kernel is booting

init: starting sh
$ echo
echo
$ ^Cmake: *** [check] Interrupt: 2
```
