### PR TITLE
Optimize riscv-tests build flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC ?= gcc
 CFLAGS = -O2 -Wall
 LDFLAGS = -lpthread
+SHELL := /bin/bash
 
 # For building riscv-tests
 CROSS_COMPILE ?= riscv64-unknown-elf-
@@ -8,8 +9,7 @@ CROSS_COMPILE ?= riscv64-unknown-elf-
 CUR_DIR := $(shell pwd)
 TESTS_DIR := $(CUR_DIR)/tests
 RISCV_TESTS_DIR := $(TESTS_DIR)/riscv-tests
-RISCV_TESTS_TARGET_DIR := $(RISCV_TESTS_DIR)/target
-RISCV_TESTS_SUITE_DIR := $(RISCV_TESTS_TARGET_DIR)/share/riscv-tests/isa
+RISCV_TESTS_ISA_DIR := $(RISCV_TESTS_DIR)/isa
 RISCV_TESTS_BIN_DIR := $(TESTS_DIR)/riscv-tests-data
 
 BIN := semu
@@ -43,18 +43,17 @@ $(RISCV_TESTS_DIR)/configure:
 # Fetch and build riscv-tests project
 # Transform the original elf format to binary format
 build-riscv-tests: $(RISCV_TESTS_DIR)/configure
-	cd $(RISCV_TESTS_DIR); autoconf; ./configure --prefix=$(RISCV_TESTS_TARGET_DIR)
-	$(MAKE) -C $(RISCV_TESTS_DIR)
-	$(MAKE) -C $(RISCV_TESTS_DIR) install
+	cd $(RISCV_TESTS_DIR); ./configure
+	$(MAKE) -C $(RISCV_TESTS_DIR) isa
 	mkdir -p $(RISCV_TESTS_BIN_DIR)
-	for file in $(RISCV_TESTS_SUITE_DIR)/rv64*; do \
-		case $$file in \
-			(*.dump) continue; \
-		esac; \
+	for file in $(RISCV_TESTS_ISA_DIR)/rv64*; do \
+		if [ -d $$file ] || [[ $$file == *.dump ]]; then \
+			continue; \
+		fi; \
 		original=$$(basename $$file); \
 		filename=$$(echo $$original | sed -e "s/-/_/g"); \
 		$(CROSS_COMPILE)objcopy -O binary $$file $(RISCV_TESTS_BIN_DIR)/$$filename; \
-		echo $$file "--> $(RISCV_TESTS_BIN_DIR)/$$filename"; \
+		echo "Transform ELF into binary:" $$file "--> $(RISCV_TESTS_BIN_DIR)/$$filename"; \
 	done
 
 riscv-tests: $(BIN) build-riscv-tests


### PR DESCRIPTION
Only build isa tests of riscv-tests for saving build time.

Also, autoconf is unnecessary since there is a pre-generated configure
file in riscv-tests repository. See issue #273:
https://github.com/riscv-software-src/riscv-tests/issues/273