### PR TITLE
Add option to test specific test binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,42 @@ $ make riscv-tests
 ```
 
 You can check the generated report as following:
+```shell
+[==========] Running 71 test(s) from riscv-tests.
+[ RUN      ] rv64ui_p_add
+[       OK ] rv64ui_p_add
+[ RUN      ] rv64ui_p_addi
+[       OK ] rv64ui_p_addi
+
+...
+
+[ RUN      ] rv64ua_p_lrsc
+  a0 = 0x80002008
+  tohost = 0x53b
+  An exception occurred.
+[  FAILED  ] rv64ua_p_lrsc
+[==========] 71 test(s) from riscv-tests ran.
+[  PASSED  ] 55 test(s).
+[  FAILED  ] 16 test(s), listed below:
+[  FAILED  ] rv64ui_p_fence_i
+[  FAILED  ] rv64ua_p_amoand_d
+...
 ```
-=======================
-Test result: 55/71
-=======================
+
+If you want to execute a specific test instead of the whole test, please run the following command:
+```shell
+$ ./semu --test <test_case_name>
+```
+
+You can refer to `tests/isa-test.c` for the name of specific test case.
+Take `rv64ui_p_add` for example, the report would be:
+```shell
+$ ./semu --test rv64ui_p_add
+[==========] Running 1 test(s) from riscv-tests.
+[ RUN      ] rv64ui_p_add
+[       OK ] rv64ui_p_add
+[==========] 1 test(s) from riscv-tests ran.
+[  PASSED  ] 1 test(s).
 ```
 
 ## Acknowledgements

--- a/tests/test.h
+++ b/tests/test.h
@@ -1,8 +1,11 @@
 #ifndef __TEST_H__
 #define __TEST_H__
 
-#define TEST_PASS 0
-#define TEST_FAIL -1
+enum {
+    TEST_Unknown = 0,
+    TEST_Passed = 1,
+    TEST_Failed = -1,
+};
 
 struct testdata {
     int result;
@@ -12,13 +15,16 @@ struct testdata {
 
 #define ADD_INSN_TEST(op)                           \
     {                                               \
-        .result = TEST_FAIL, .name = #op,           \
+        .result = TEST_Unknown, .name = #op,        \
         .file_path = "tests/riscv-tests-data/" #op, \
     }
 
 extern struct testdata riscv_tests[];
 extern const int n_riscv_tests;
 
-void print_test_result(void);
+void print_test_iter_start(int n_test);
+void print_test_start(struct testdata *test);
+void print_test_end(struct testdata *test, uint64_t a0, uint64_t tohost);
+void print_test_iter_end(int n_tested);
 
 #endif


### PR DESCRIPTION
Current test command always tests whole test cases. This patch
adds an option to run just one specific test case. It is useful
when we plan to re-run certain instruction test(s). For example:

    ./semu --test rv64ui_p_add

Also, this patch makes the log of test result more pretty.
Now the test log would be:

    [ RUN      ] rv64ua_p_lrsc
      a0 = 0x80002008
      tohost = 0x53b
      An exception occurred.
    [  FAILED  ] rv64ua_p_lrsc
    [==========] 71 test from riscv-tests ran
    [  PASSED  ] 55 test
    [  FAILED  ] 16 test, listed below:
    [  FAILED  ] rv64ui_p_fence_i
    [  FAILED  ] rv64ua_p_amoand_d