### PR TITLE
Fix the pass condition of riscv-tests

### DIFF
--- a/semu.c
+++ b/semu.c
@@ -1401,11 +1401,11 @@ void run_riscv_test(struct cpu *cpu, int idx)
     }
 
     /*
-     * Test result is stored at a0 (x10).
-     * The riscv-tests set a0 to 0 when all tests pass.
-     * Otherwise it indicates a failure or exception.
+     * The riscv-tests set a0 to 0 and tohost to 1 when all tests are
+     * successful. Otherwise it indicates a failure or exception.
      */
-    riscv_tests[idx].result = (cpu->regs[10] == 0) ? TEST_Passed : TEST_Failed;
+    bool success = (cpu->regs[10] == 0) && (tohost == 1);
+    riscv_tests[idx].result = success ? TEST_Passed : TEST_Failed;
     print_test_end(&riscv_tests[idx], cpu->regs[10], tohost);
 }
 


### PR DESCRIPTION
Previous code only checks if the register a0 equals zero or not to
determine if the test is passed. But there will be a bug if semu has
not implemented the tested instruction yet. Semu always regards this
kind of instruction as an illegal instruction, and further triggers
an exception. If there is an exception, the riscv-tests will set the
"tohost" variable other than 1, and stuck in an infinite loop. Since
the test is not finished, the value of a0 is meaningless.

This patch fixes the pass condition that semu checks not only a0,
but also the tohost variable, to determine the result of the test.