### PR TITLE
Remove duplicated test item

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ make ENABLE_RISCV_TESTS=1 clean run-tests
 
 You can check the generated report as following:
 ```shell
-[==========] Running 71 test(s) from riscv-tests.
+[==========] Running 70 test(s) from riscv-tests.
 [ RUN      ] rv64ui-p-add
 [       OK ] rv64ui-p-add
 [ RUN      ] rv64ui-p-addi
@@ -65,8 +65,8 @@ You can check the generated report as following:
   tohost = 0x53b
   An exception occurred.
 [  FAILED  ] rv64ua-p-lrsc
-[==========] 71 test(s) from riscv-tests ran.
-[  PASSED  ] 55 test(s).
+[==========] 70 test(s) from riscv-tests ran.
+[  PASSED  ] 54 test(s).
 [  FAILED  ] 16 test(s), listed below:
 [  FAILED  ] rv64ui-p-fence_i
 [  FAILED  ] rv64ua-p-amoand_d

--- a/tests/isa-test.c
+++ b/tests/isa-test.c
@@ -9,7 +9,6 @@ struct testdata riscv_tests[] = {
     /* rv64ui-p-* */
     ADD_INSN_TEST(rv64ui-p-add),
     ADD_INSN_TEST(rv64ui-p-addi),
-    ADD_INSN_TEST(rv64ui-p-addi),
     ADD_INSN_TEST(rv64ui-p-addiw),
     ADD_INSN_TEST(rv64ui-p-addw),
     ADD_INSN_TEST(rv64ui-p-and),


### PR DESCRIPTION
Remove duplicated test item, now the result of riscv-tests should be:

    [  FAILED  ] rv64ua-p-lrsc
    [==========] 70 test(s) from riscv-tests ran.
    [  PASSED  ] 54 test(s).
    [  FAILED  ] 16 test(s), listed below:
    [  FAILED  ] rv64ui-p-fence_i
    [  FAILED  ] rv64ua-p-amoand_d