### PR TITLE
Minor improvements for macOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,24 @@ $ ./semu --test rv64ui-p-add
 [  PASSED  ] 1 test(s).
 ```
 
+### Note for macOS users
+On macOS, `md5sum` is no longer installed by default so you might run into errors like below while running RISC-V tests.
+```shell
+semu/tests/riscv-tests/isa/../env/v/vm.c: In function 'vm_boot':
+<command-line>: error: invalid suffix "x" on integer constant
+semu/tests/riscv-tests/isa/../env/v/vm.c:228:21: note: in expansion of macro 'ENTROPY'
+  228 |   uint64_t random = ENTROPY;
+      |                     ^~~~~~~
+```
+It is because of how `ENTROPY` was defined in [riscv-test/isa/Makefile](https://github.com/riscv-software-src/riscv-tests/blob/74a62ef0f3eefa759c1c49ae1c756879232f96da/isa/Makefile#L64)
+
+```
+-DENTROPY=0x$$(shell echo \$$@ | md5sum | cut -c 1-7)
+```
+
+You can fix it by `brew install md5sha1sum`, see [reference](https://github.com/riscv-software-src/riscv-tests/issues/190).
+
+
 ## Acknowledgements
 
 `semu` is inspired by [rvemu](https://github.com/d0iasm/rvemu).

--- a/scripts/gen-isa-test-list.sh
+++ b/scripts/gen-isa-test-list.sh
@@ -5,7 +5,7 @@ function parse-tests()
     # TODO: cache the parsed test items
     while read -r line; do
 	echo "$line" | awk -F "(" '{print $2}' | awk -F ")" '{print $1}'
-    done <<< $(grep "ADD_INSN_TEST" tests/isa-test.c)
+    done < <(grep "ADD_INSN_TEST" tests/isa-test.c)
 }
 
 parse-tests


### PR DESCRIPTION
### Note to reviewers
 - Refer to https://github.com/riscv-software-src/riscv-tests/issues/190 in README
 - It could be just me, but `scripts/gen-isa-test-list.sh` doesn't iterate through the `testdata` struct in `isa-test.c`. I tested it on bash version `3.2.57(1)-release` (on macOS Monterey 12.4) as well as on `version 4.2.46(2)-release` (on CentOS 7). Here is the result:
```shell
$ ./gen-isa-test-list.sh 
rv64ui-p-add

$ cat /etc/*-release
CentOS Linux release 7.9.2009 (Core)
NAME="CentOS Linux"
```
 - Therefore, I replaced the here string with process substitution in `scripts/gen-isa-test-list.sh`.


### Tests
 - Ran `gen-isa-test-list.sh ` on CentOS 7 and macOS Monterey 12.4:

```shell
$ ls -R 
gen-isa-test-list.sh  tests
                                                         
./tests:     
isa-test.c 

$ ./gen-isa-test-list.sh 
rv64ui-p-add 
rv64ui-p-addi    
rv64ui-p-addi
...(omitted)
rv64ua-p-amoxor_w
rv64ua-p-lrsc

$ ./scripts/gen-isa-test-list.sh | wc -l
      70
```

 - Ran RISC-V tests on my Mac (macOS Monterey 12.4):
```shell
$ make clean ENABLE_RISCV_TESTS=1 run-tests

cc -o semu semu.o tests/isa-test.o -lpthread
./semu --test
[==========] Running 70 test(s) from riscv-tests.
...(omitted)
[==========] 70 test(s) from riscv-tests ran.
[  PASSED  ] 54 test(s).
[  FAILED  ] 16 test(s), listed below:
[  FAILED  ] rv64ui-p-fence_i
[  FAILED  ] rv64ua-p-amoand_d
[  FAILED  ] rv64ua-p-amoand_w
[  FAILED  ] rv64ua-p-amomax_d
[  FAILED  ] rv64ua-p-amomax_w
[  FAILED  ] rv64ua-p-amomaxu_d
[  FAILED  ] rv64ua-p-amomaxu_w
[  FAILED  ] rv64ua-p-amomin_d
[  FAILED  ] rv64ua-p-amomin_w
[  FAILED  ] rv64ua-p-amominu_d
[  FAILED  ] rv64ua-p-amominu_w
[  FAILED  ] rv64ua-p-amoor_d
[  FAILED  ] rv64ua-p-amoor_w
[  FAILED  ] rv64ua-p-amoxor_d
[  FAILED  ] rv64ua-p-amoxor_w
[  FAILED  ] rv64ua-p-lrsc
```
