### PR TITLE
Remove extra parentheses

### DIFF
--- a/mk/riscv-tests.mk
+++ b/mk/riscv-tests.mk
@@ -16,7 +16,7 @@ ifndef CROSS_COMPILE
 	$(error "GNU Toolchain for RISC-V is required. Please check package installation")
 endif
 	$(VECHO) "Building riscv-tests...\n"
-	$(Q)$(cd $(RISCV_TESTS_DIR); ./configure) $(REDIR)
+	$(Q) cd $(RISCV_TESTS_DIR); ./configure $(REDIR)
 	$(Q)$(MAKE) -C $(RISCV_TESTS_DIR) RISCV_PREFIX=$(CROSS_COMPILE) isa -j $(shell nproc) $(REDIR)
 
 # Convert generated ELF files to raw binary


### PR DESCRIPTION
### Note to reviewers
 - It could be just me, but it seems like the extra parentheses made `cd $(RISCV_TESTS_DIR); ./configure` ineffective. Therefore, the `Makefile` in `tests/riscv-tests` wasn't generated when I built a fresh checkout of `semu`.
 - Tested on macOS Monterey 12.4. I'll try to test it on CentOS tomorrow.
 - Thanks for making the build modularized :)

### Tests
 - Here is a fresh checkout of the `semu` repo
```shell
➜  semu git:(master) git diff
➜  semu git:(master) git s
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
➜  semu git:(master) make ENABLE_RISCV_TESTS=1 clean run-tests        
  CC	semu.o
  CC	tests/isa-test.o

(omitted)

Building riscv-tests...
riscv64-unknown-elf-objcopy: 'tests/riscv-tests/isa/rv64ui-p-add': No such file
make: *** [tests/riscv-tests-data/rv64ui-p-add] Error 1
```
 - After I removed the parentheses
```shell
➜  semu git:(master) vi mk/riscv-tests.mk 
➜  semu git:(master) ✗ git s                                    
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   mk/riscv-tests.mk

no changes added to commit (use "git add" and/or "git commit -a")
➜  semu git:(master) ✗ make ENABLE_RISCV_TESTS=1 clean run-tests
  CC	semu.o
  CC	tests/isa-test.o

(omitted)

Building riscv-tests...
configure: WARNING: using cross tools not prefixed with host triplet
[==========] Running 70 test(s) from riscv-tests.

(omitted)

[==========] 70 test(s) from riscv-tests ran.
[  PASSED  ] 54 test(s).

(omitted)
```