### PR TITLE
Implement more RV64M instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ make ENABLE_RISCV_TESTS=1 clean run-tests
 
 You can check the generated report as following:
 ```shell
-[==========] Running 70 test(s) from riscv-tests.
+[==========] Running 83 test(s) from riscv-tests.
 [ RUN      ] rv64ui-p-add
 [       OK ] rv64ui-p-add
 [ RUN      ] rv64ui-p-addi
@@ -65,8 +65,8 @@ You can check the generated report as following:
   tohost = 0x53b
   An exception occurred.
 [  FAILED  ] rv64ua-p-lrsc
-[==========] 70 test(s) from riscv-tests ran.
-[  PASSED  ] 54 test(s).
+[==========] 83 test(s) from riscv-tests ran.
+[  PASSED  ] 67 test(s).
 [  FAILED  ] 16 test(s), listed below:
 [  FAILED  ] rv64ui-p-fence_i
 [  FAILED  ] rv64ua-p-amoand_d

--- a/mul128.h
+++ b/mul128.h
@@ -1,0 +1,36 @@
+#ifndef __SEMU_MUL128_H__
+#define __SEMU_MUL128_H__
+
+#include <stdint.h>
+
+static inline uint64_t mulhu(uint64_t u, uint64_t v)
+{
+    uint64_t a = u >> 32;
+    uint64_t b = u & 0xffffffff;
+    uint64_t c = v >> 32;
+    uint64_t d = v & 0xffffffff;
+
+    uint64_t ac = a * c;
+    uint64_t bc = b * c;
+    uint64_t ad = a * d;
+    uint64_t bd = b * d;
+
+    uint64_t mid34 = (bd >> 32) + (bc & 0xffffffff) + (ad & 0xffffffff);
+
+    uint64_t hi64 = ac + (bc >> 32) + (ad >> 32) + (mid34 >> 32);
+
+    return hi64;
+}
+
+static inline int64_t mulh(int64_t u, int64_t v)
+{
+    return mulhu((uint64_t) u, (uint64_t) v) - ((u < 0) ? v : 0) -
+           ((v < 0) ? u : 0);
+}
+
+static inline uint64_t mulhsu(int64_t u, uint64_t v)
+{
+    return mulhu((uint64_t) u, (uint64_t) v) - ((u < 0) ? v : 0);
+}
+
+#endif

--- a/tests/isa-test.c
+++ b/tests/isa-test.c
@@ -59,6 +59,21 @@ struct testdata riscv_tests[] = {
     ADD_INSN_TEST(rv64ui-p-xor),
     ADD_INSN_TEST(rv64ui-p-xori),
 
+    /* rv64um-p-* */
+    ADD_INSN_TEST(rv64um-p-div),
+    ADD_INSN_TEST(rv64um-p-divu),
+    ADD_INSN_TEST(rv64um-p-divuw),
+    ADD_INSN_TEST(rv64um-p-divw),
+    ADD_INSN_TEST(rv64um-p-mul),
+    ADD_INSN_TEST(rv64um-p-mulh),
+    ADD_INSN_TEST(rv64um-p-mulhsu),
+    ADD_INSN_TEST(rv64um-p-mulhu),
+    ADD_INSN_TEST(rv64um-p-mulw),
+    ADD_INSN_TEST(rv64um-p-rem),
+    ADD_INSN_TEST(rv64um-p-remu),
+    ADD_INSN_TEST(rv64um-p-remuw),
+    ADD_INSN_TEST(rv64um-p-remw),
+
     /* rv64ua-p-* */
     ADD_INSN_TEST(rv64ua-p-amoadd_d),
     ADD_INSN_TEST(rv64ua-p-amoadd_w),


### PR DESCRIPTION
Implements more RV64M instructions and adds corresponding tests. Now the result of tests becomes:

    [ RUN      ] rv64ua-p-lrsc
      a0 = 0x80002008
      tohost = 0x53b
      An exception occurred.
    [  FAILED  ] rv64ua-p-lrsc
    [==========] 83 test(s) from riscv-tests ran.
    [  PASSED  ] 67 test(s).
    [  FAILED  ] 16 test(s), listed below:
    [  FAILED  ] rv64ui-p-fence_i
    [  FAILED  ] rv64ua-p-amoand_d