### PR TITLE
Implement RV32 and RV64 AMO instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,10 @@ You can check the generated report as following:
   An exception occurred.
 [  FAILED  ] rv64ua-p-lrsc
 [==========] 83 test(s) from riscv-tests ran.
-[  PASSED  ] 67 test(s).
-[  FAILED  ] 16 test(s), listed below:
+[  PASSED  ] 81 test(s).
+[  FAILED  ] 2 test(s), listed below:
 [  FAILED  ] rv64ui-p-fence_i
-[  FAILED  ] rv64ua-p-amoand_d
-...
+[  FAILED  ] rv64ua-p-lrsc
 ```
 
 If you want to execute a specific test instead of the whole test, please run the following command:


### PR DESCRIPTION
Besides, the static keyword is added to the inline functions to fix undefined reference issue and let the compiler force inline those functions.

Now the result of tests becomes:

    [==========] 83 test(s) from riscv-tests ran.
    [  PASSED  ] 81 test(s).
    [  FAILED  ] 2 test(s), listed below:
    [  FAILED  ] rv64ui-p-fence_i
    [  FAILED  ] rv64ua-p-lrsc