### PR TITLE
Handle UART input with termios

### DIFF
--- a/device.h
+++ b/device.h
@@ -68,6 +68,7 @@ void u8250_write(vm_t *core,
                  uint8_t width,
                  uint32_t value);
 void u8250_check_ready(u8250_state_t *uart);
+void capture_keyboard_input();
 
 /* VirtIO-Net */
 

--- a/main.c
+++ b/main.c
@@ -267,6 +267,7 @@ static int semu_start(int argc, char **argv)
 
     /* Set up peripherals */
     emu.uart.in_fd = 0, emu.uart.out_fd = 1;
+    capture_keyboard_input(); /* set up uart */
 #if defined(ENABLE_VIRTIONET)
     if (!virtio_net_init(&(emu.vnet)))
         fprintf(stderr, "No virtio-net functioned\n");


### PR DESCRIPTION
The original keybord input handling in UART generates an extra endline character, which causes tab completion and vi editor fauilure.

This change incorparates termios function to address the above issue. Following this change, users can utilize the vi editor, benefit from tab completion, and exit semu by pressing Ctrl-a followed by x.