### PR TITLE
Add PulseAudio dependency CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,21 @@ on: [push, pull_request]
 jobs:
   semu-linux:
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        dependency:
+          - libpulse-dev
+          - none
     steps:
-    - uses: actions/checkout@v4
+    - name: checkout code
+      uses: actions/checkout@v4
     - name: install-dependencies
       run: |
             sudo apt-get install build-essential device-tree-compiler expect
             sudo apt-get install libasound2-dev libudev-dev
+    - name: install sound multiplexer ${{ matrix.dependency }}
+      if: matrix.dependency != 'none'
+      run: sudo apt-get install ${{ matrix.dependency }}
     - name: default build
       run: make
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,13 @@ endif
 
 ifeq ($(UNAME_S),Linux)
     # Check ALSA installation
-    ifeq (0, $(call check-alsa))
+    ifeq (1, $(call check-alsa))
         $(warning No libasound installed. Check libasound in advance.)
         ENABLE_VIRTIOSND := 0
     endif
 endif
 ifeq ($(UNAME_S),Darwin)
-    ifeq (0, $(call check-coreaudio))
+    ifeq (1, $(call check-coreaudio))
         $(warning No CoreAudio installed Check AudioToolbox in advance.)
         ENABLE_VIRTIOSND := 0
     endif

--- a/mk/check-libs.mk
+++ b/mk/check-libs.mk
@@ -34,17 +34,17 @@ endef
 
 # Check ALSA installation
 define check-alsa
-$(shell $(call create-alsa-prog) | $(CC) -x c -lasound -o /dev/null > /dev/null 2> /dev/null - 
-	&& echo $$?)
+$(shell $(call create-alsa-prog) | $(CC) -x c - -lasound -o /dev/null > /dev/null 2> /dev/null 
+	&& echo 0 || echo 1)
 endef
 
 # Check PulseAudio installation
 define check-pa
-$(shell $(call create-pa-prog) | $(CC) -x c -lpulse -o /dev/null - && echo 0 || echo 1)
+$(shell $(call create-pa-prog) | $(CC) -x c - -lpulse -o /dev/null && echo 0 || echo 1)
 endef
 
 # Check CoreAudio installation
 define check-coreaudio
-$(shell $(call create-ca-prog) | $(CC) -x c -framework AudioToolbox -o /dev/null > /dev/null 2> /dev/null - 
-	&& echo $$?)
+$(shell $(call create-ca-prog) | $(CC) -x c - -framework AudioToolbox -o /dev/null > /dev/null 2> /dev/null 
+	&& echo 0 || echo 1)
 endef


### PR DESCRIPTION
Add PulseAudio dependency CI for testing Linux system with PulseAudio installed.

Also, fix the bogus libraries detection.

Mention #87.