### PR TITLE
Implement MMU translation caching with 2-way load

### DIFF
--- a/main.c
+++ b/main.c
@@ -8,6 +8,9 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#ifdef MMU_CACHE_STATS
+#include <sys/time.h>
+#endif
 
 #include "device.h"
 #include "mini-gdbstub/include/gdbstub.h"
@@ -395,11 +398,11 @@ static inline sbi_ret_t handle_sbi_ecall_RFENCE(hart_t *hart, int32_t fid)
         hart_mask_base = (uint64_t) hart->x_regs[RV_R_A1];
         if (hart_mask_base == 0xFFFFFFFFFFFFFFFF) {
             for (uint32_t i = 0; i < hart->vm->n_hart; i++) {
-                hart->vm->hart[i]->cache_fetch.n_pages = 0xFFFFFFFF;
+                mmu_invalidate(hart->vm->hart[i]);
             }
         } else {
             for (int i = hart_mask_base; hart_mask; hart_mask >>= 1, i++) {
-                hart->vm->hart[i]->cache_fetch.n_pages = 0xFFFFFFFF;
+                mmu_invalidate(hart->vm->hart[i]);
             }
         }
         return (sbi_ret_t){SBI_SUCCESS, 0};
@@ -796,9 +799,57 @@ static int semu_step(emu_state_t *emu)
     return 0;
 }
 
+#ifdef MMU_CACHE_STATS
+static void print_mmu_cache_stats(vm_t *vm)
+{
+    fprintf(stderr, "\n=== MMU Cache Statistics ===\n");
+    for (uint32_t i = 0; i < vm->n_hart; i++) {
+        hart_t *hart = vm->hart[i];
+        uint64_t fetch_total =
+            hart->cache_fetch.hits + hart->cache_fetch.misses;
+
+        /* Combine 2-way load cache statistics */
+        uint64_t load_hits =
+            hart->cache_load[0].hits + hart->cache_load[1].hits;
+        uint64_t load_misses =
+            hart->cache_load[0].misses + hart->cache_load[1].misses;
+        uint64_t load_total = load_hits + load_misses;
+
+        uint64_t store_total =
+            hart->cache_store.hits + hart->cache_store.misses;
+
+        fprintf(stderr, "\nHart %u:\n", i);
+        fprintf(stderr, "  Fetch: %12llu hits, %12llu misses",
+                hart->cache_fetch.hits, hart->cache_fetch.misses);
+        if (fetch_total > 0)
+            fprintf(stderr, " (%.2f%% hit rate)",
+                    100.0 * hart->cache_fetch.hits / fetch_total);
+        fprintf(stderr, "\n");
+
+        fprintf(stderr, "  Load:  %12llu hits, %12llu misses (2-way)",
+                load_hits, load_misses);
+        if (load_total > 0)
+            fprintf(stderr, " (%.2f%% hit rate)",
+                    100.0 * load_hits / load_total);
+        fprintf(stderr, "\n");
+
+        fprintf(stderr, "  Store: %12llu hits, %12llu misses",
+                hart->cache_store.hits, hart->cache_store.misses);
+        if (store_total > 0)
+            fprintf(stderr, " (%.2f%% hit rate)",
+                    100.0 * hart->cache_store.hits / store_total);
+        fprintf(stderr, "\n");
+    }
+}
+#endif
+
 static int semu_run(emu_state_t *emu)
 {
     int ret;
+#ifdef MMU_CACHE_STATS
+    struct timeval start_time, current_time;
+    gettimeofday(&start_time, NULL);
+#endif
 
     /* Emulate */
     while (!emu->stopped) {
@@ -833,6 +884,23 @@ static int semu_run(emu_state_t *emu)
             ret = semu_step(emu);
             if (ret)
                 return ret;
+#ifdef MMU_CACHE_STATS
+            /* Exit after running for 15 seconds to collect statistics */
+            gettimeofday(&current_time, NULL);
+            long elapsed_sec = current_time.tv_sec - start_time.tv_sec;
+            long elapsed_usec = current_time.tv_usec - start_time.tv_usec;
+            if (elapsed_usec < 0) {
+                elapsed_sec--;
+                elapsed_usec += 1000000;
+            }
+            long elapsed = elapsed_sec + (elapsed_usec > 0 ? 1 : 0);
+            if (elapsed >= 15) {
+                fprintf(stderr,
+                        "\n[MMU_CACHE_STATS] Reached 15 second time limit, "
+                        "exiting...\n");
+                return 0;
+            }
+#endif
         }
     }
 
@@ -964,7 +1032,13 @@ int main(int argc, char **argv)
         return ret;
 
     if (emu.debug)
-        return semu_run_debug(&emu);
+        ret = semu_run_debug(&emu);
+    else
+        ret = semu_run(&emu);
 
-    return semu_run(&emu);
+#ifdef MMU_CACHE_STATS
+    print_mmu_cache_stats(&emu.vm);
+#endif
+
+    return ret;
 }


### PR DESCRIPTION
This adds TLB to cache virtual-to-physical address translations:
- cache_fetch: 1-entry direct-mapped for instruction fetch
- cache_load: 2-entry direct-mapped with hash-based indexing
- cache_store: 1-entry direct-mapped for data stores

Cache invalidation handled at all necessary points: SATP writes, fence instructions, mode switches, and trap entry/exit.

Optional statistics support via MMU_CACHE_STATS compile flag shows ~96% fetch, ~69% load, and ~84% store hit rates during kernel boot.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a small TLB for MMU translations: 1-entry caches for fetch/store and a 2-way cache for loads. This cuts page-table walks and speeds up memory access, with optional per-hart hit/miss stats.

- New Features
  - 1-entry direct-mapped fetch and store translation caches.
  - 2-way set-associative load translation cache (indexed by VPN bit 0).
  - Central mmu_invalidate clears all caches; RFENCE now calls it.
  - MMU_CACHE_STATS flag: per-hart hit/miss counters and a summary printout; run exits after 15s to dump stats.
  - Observed hit rates: ~96% fetch, ~69% load, ~84% store during kernel boot.

- Bug Fixes
  - LR/SC reservations now track physical addresses to avoid alias issues.

<!-- End of auto-generated description by cubic. -->

