### PR TITLE
Enable CONFIG_PACKET

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,9 @@ build-image:
 clean:
 	$(Q)$(RM) $(BIN) $(OBJS) $(deps)
 	$(Q)$(MAKE) -C mini-gdbstub clean
-	$(Q)$(MAKE) -C minislirp/src clean
+	$(Q)if [ -n "$(MINISLIRP_DIR)" ] && [ -d "$(MINISLIRP_DIR)/src" ]; then \
+		$(MAKE) -C $(MINISLIRP_DIR)/src clean; \
+	fi
 
 distclean: clean
 	$(Q)$(RM) riscv-harts.dtsi

--- a/configs/linux.config
+++ b/configs/linux.config
@@ -472,7 +472,7 @@ CONFIG_NET=y
 #
 # Networking options
 #
-# CONFIG_PACKET is not set
+CONFIG_PACKET=y
 CONFIG_UNIX=y
 CONFIG_UNIX_SCM=y
 CONFIG_AF_UNIX_OOB=y

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -35,7 +35,7 @@ function do_buildroot
 {
     if [ ! -d buildroot ]; then
         echo "Cloning Buildroot..."
-        ASSERT git clone https://github.com/buildroot/buildroot -b 2024.11.1 --depth=1
+        ASSERT git clone https://github.com/buildroot/buildroot -b 2025.02.x --depth=1
     else
         echo "buildroot/ already exists, skipping clone"
     fi


### PR DESCRIPTION
Without CONFIG_PACKET, the kernel refuses AF_PACKET sockets, so those utilities can't run. For user-level networking in virtualized setups especially when the test harness relies on DHCP. Thus, we should enable CONFIG_PACKET (built-in or module) in the guest kernel.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable CONFIG_PACKET in the guest kernel to allow AF_PACKET sockets. This unblocks DHCP and user-level networking in virtualized test runs.

- **Bug Fixes**
  - Set CONFIG_PACKET=y so tools using raw packet sockets (e.g., DHCP) work.
  - Guard minislirp clean to avoid errors when the dir is missing.

- **Dependencies**
  - Bump Buildroot to 2025.02.x in build-image.sh.

<!-- End of auto-generated description by cubic. -->

