### PR TITLE
Reduce RFENCE IPI cache flush scope

### DIFF
--- a/riscv.h
+++ b/riscv.h
@@ -190,3 +190,6 @@ void vm_error_report(const hart_t *vm);
 
 /* Invalidate all MMU translation caches (fetch, load, store) */
 void mmu_invalidate(hart_t *vm);
+
+/* Invalidate MMU caches for a specific virtual address range */
+void mmu_invalidate_range(hart_t *vm, uint32_t start_addr, uint32_t size);


### PR DESCRIPTION
This optimizes RFENCE.VMA to use range-based cache invalidation instead of unconditionally flushing all MMU caches. It adds mmu_invalidate_range that selectively invalidates only cache entries within the specified virtual address range, reducing cache flushes by 75-100% for single-page operations.

SBI compliance: size==0 and size==-1 trigger full flush per specification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope RFENCE.VMA cache invalidation to the requested virtual address range to reduce unnecessary flushes and speed up single-page operations. Full flush still occurs when size is 0 or -1 per SBI, reducing flushes by 75–100% on single-page cases.

- **New Features**
  - Added mmu_invalidate_range(hart, start_addr, size) and used it for RFENCE.VMA/VMA.ASID with hart mask selection.
  - Computed end of range with 64‑bit arithmetic and clamped to RV32 to avoid overflow.

<sup>Written for commit fb11de898562c7a28b1dd41c3afa14ddf56ef6af. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

