### PR TITLE
Fix 'num_request_queues' exceeding allocated slots

### DIFF
--- a/virtio-fs.c
+++ b/virtio-fs.c
@@ -935,7 +935,7 @@ bool virtio_fs_init(virtio_fs_state_t *vfs, char *mtag, char *dir)
     memcpy(vfs->shared_dir, dir, dir_len);
 
     snprintf(PRIV(vfs)->tag, sizeof(PRIV(vfs)->tag), "%s", mtag);
-    PRIV(vfs)->num_request_queues = 3;
+    PRIV(vfs)->num_request_queues = 2;
     vfs->mount_tag = mtag;
 
     inode_map_entry *root_entry = malloc(sizeof(inode_map_entry));


### PR DESCRIPTION
Currently, `virtio_fs_init` set `num_request_queues = 3`, but `virtio_fs_state_t.queues` only has three slots (index 0–2). With SMP >= 3, the guest driver calculates `nvqs = 1 + min(3, nr_cpu_ids) = 4` and attempts to set up four virtqueues. The host rejects `QueueSel = 3` silently (index out of bounds), then returns stale data for `QueueReady`, causing the guest probe to fail.

The resulting slab corruption panics the kernel as soon as any subsequent device allocates memory.

## Fix

Set `num_request_queues = 2` to match the two request queue slots (`queues[1]` and `queues[2]`) actually available.

## Reproduce (before fix)

Temporarily move the `fs0` node in `minimal.dts` to appear before other virtio devices, make it probes before other devices. Then run:

```bash
make check SMP=4
```

The output:

```
[    0.022267] smp: Bringing up secondary CPUs ...
[    0.050295] smp: Brought up 1 node, 4 CPUs
[    0.069291] Memory: 502644K/524288K available (4623K kernel code, 361K rwdata, 1248K rodata, 227K init, 141K bss, 20024K reserved, 0K cma-reserved)
[    0.081414] devtmpfs: initialized
[    0.141406] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.142734] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.176190] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.316045] Advanced Linux Sound Architecture Driver Initialized.
[    0.332251] clocksource: Switched to clocksource riscv_clocksource
[    0.658717] NET: Registered PF_INET protocol family
[    0.666489] IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.741634] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.743114] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.744526] TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
[    0.748087] TCP bind hash table entries: 4096 (order: 4, 65536 bytes, linear)
[    0.752749] TCP: Hash tables configured (established 4096 bind 4096)
[    0.754923] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.756558] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.761073] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.774770] Unpacking initramfs...
[    0.787752] workingset: timestamp_bits=30 max_order=17 bucket_order=0
[    0.798626] fuse: init (API version 7.41)
[    0.866922] riscv-plic: interrupt-controller@0: mapped 31 interrupts with 4 handlers for 4 contexts.
[    0.892363] virtiofs virtio0: probe with driver virtiofs failed with error -2
[    0.904523] Unable to handle kernel paging request at virtual address 72697636
[    0.905499] Oops [#1]
[    0.906040] Modules linked in:
[    0.906736] CPU: 3 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.12.67 #1
[    0.907872] Hardware name: semu (DT)
[    0.908534] epc : __kmalloc_node_track_caller_noprof+0xd0/0x158
[    0.909661]  ra : __kmalloc_node_track_caller_noprof+0x7c/0x158
[    0.910789] epc : c00f6c9c ra : c00f6c48 sp : c083fc30
[    0.911719]  gp : c0650070 tp : c0848000 t0 : 00000000
[    0.912661]  t1 : c095c19f t2 : 69747269 s0 : c083fc50
[    0.913589]  s1 : 7269762e a0 : c0801280 a1 : 7269762e
[    0.914517]  a2 : ffffffff a3 : 00000090 a4 : 00000090
[    0.915393]  a5 : 72697636 a6 : 0000000c a7 : 00000118
[    0.916312]  s2 : c0801280 s3 : 00000010 s4 : 00000cc0
[    0.917190]  s5 : ffffffff s6 : c066af10 s7 : 00000004
[    0.918083]  s8 : 0000a1ff s9 : 00000000 s10: 00000000
[    0.918921]  s11: 00000000 t3 : c04cfab8 t4 : c02fab50
[    0.919817]  t5 : c0658314 t6 : c09d920d
[    0.920613] status: 00000120 badaddr: 72697636 cause: 0000000d
[    0.921547] [<c00f6c9c>] __kmalloc_node_track_caller_noprof+0xd0/0x158
[    0.922806] [<c00c2254>] kstrdup+0x4c/0x8c
[    0.923848] [<c00c22c0>] kstrdup_const+0x2c/0x40
[    0.924969] [<c01700d0>] __kernfs_new_node.isra.0+0x60/0x1e8
[    0.926083] [<c0171088>] kernfs_new_node+0x74/0xa4
[    0.927138] [<c017359c>] kernfs_create_link+0x48/0xc0
[    0.928308] [<c0174bf0>] sysfs_do_create_link_sd+0xc4/0xfc
[    0.929511] [<c0174c58>] sysfs_create_link+0x30/0x4c
[    0.930651] [<c02f4c98>] driver_sysfs_add+0x3c/0x98
[    0.931763] [<c02f59ec>] really_probe+0xac/0x274
[    0.932919] [<c02f5dc0>] __driver_probe_device+0x20c/0x214
[    0.934119] [<c02f5e8c>] driver_probe_device+0x48/0xc8
[    0.935283] [<c02f6100>] __driver_attach+0x114/0x124
[    0.936472] [<c02f3660>] bus_for_each_dev+0x80/0xc8
[    0.937555] [<c02f50d8>] driver_attach+0x28/0x38
[    0.938639] [<c02f4788>] bus_add_driver+0x114/0x230
[    0.939749] [<c02f6cb4>] driver_register+0xd8/0x118
[    0.940958] [<c02f8474>] __platform_driver_register+0x28/0x38
[    0.942246] [<c04a1364>] virtio_mmio_init+0x24/0x34
[    0.943495] [<c000110c>] do_one_initcall+0x6c/0x25c
[    0.944574] [<c0485ee0>] kernel_init_freeable+0x21c/0x220
[    0.945816] [<c047dcc4>] kernel_init+0x24/0x120
[    0.946987] [<c0484b98>] ret_from_exception_end+0x14/0x20
[    0.948712] Code: 8063 0807 2783 01c9 0693 0007 8593 0004 87b3 00f4 (a603) 0007 
[    0.950165] ---[ end trace 0000000000000000 ]---
[    0.950923] Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b
[    0.951894] SMP: stopping secondary CPUs
[    0.952657] ---[ end Kernel panic - not syncing: Attempted to kill init! exitcode=0x0000000b ]---
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the virtio-fs request queue count to match allocated slots. num_request_queues is now 2 (queues[1] and queues[2]) to prevent out-of-bounds QueueSel, stale QueueReady, and probe-time kernel panics on SMP >= 3.

<sup>Written for commit 8e7b4f58cbf5cf27c6425e21781a3f2c5483e513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

