### PR TITLE
Fix buffer overflow in UART output buffering

### DIFF
--- a/uart.c
+++ b/uart.c
@@ -106,9 +106,13 @@ void u8250_flush_out(u8250_state_t *uart)
 
 static void u8250_handle_out(u8250_state_t *uart, uint8_t value)
 {
+    if (uart->out_buf_len >= sizeof(uart->out_buf))
+        u8250_flush_out(uart);
+    if (uart->out_buf_len >= sizeof(uart->out_buf))
+        return; /* flush failed, drop byte rather than corrupt memory */
     uart->out_buf[uart->out_buf_len++] = value;
     if (value == '\n' || value == '\r' || value == ':' || value == '#' ||
-        value == '$' || uart->out_buf_len >= sizeof(uart->out_buf))
+        value == '$')
         u8250_flush_out(uart);
 }
 


### PR DESCRIPTION
u8250_handle_out wrote to the buffer before checking bounds. If a prior flush failed (write error), out_buf_len stayed at 128 and the next call wrote past the end of out_buf, corrupting out_buf_len (adjacent struct field).

Move the bounds check before the write so the invariant out_buf_len<128 holds at every array access. When flush cannot drain a full buffer, drop the byte rather than corrupt memory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a buffer overflow in the UART output path by checking buffer bounds before writing, flushing when full, and dropping the byte if the flush fails to prevent memory corruption. Also removes the redundant "flush when full" condition from the newline/marker path, since fullness is handled before the write.

<sup>Written for commit 07c058c00f9fbd186add02b3ef3275e5a8ea8041. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

