### PR TITLE
Harden VirtIO, PLIC, ACLINT, and SBI

### DIFF
--- a/aclint.c
+++ b/aclint.c
@@ -30,6 +30,8 @@ static bool aclint_mtimer_reg_read(mtimer_state_t *mtimer,
 
     /* mtimecmp (0x4300000 ~ 0x4307FF8) */
     if (addr < 0x7FF8) {
+        if ((addr >> 3) >= mtimer->n_hart)
+            return false;
         *value =
             (uint32_t) (mtimer->mtimecmp[addr >> 3] >> (addr & 0x4 ? 32 : 0));
         return true;
@@ -58,6 +60,8 @@ static bool aclint_mtimer_reg_write(mtimer_state_t *mtimer,
 
     /* mtimecmp (0x4300000 ~ 0x4307FF8) */
     if (addr < 0x7FF8) {
+        if ((addr >> 3) >= mtimer->n_hart)
+            return false;
         uint64_t cmp_val = mtimer->mtimecmp[addr >> 3];
 
         if (addr & 0x4)
@@ -129,6 +133,8 @@ static bool aclint_mswi_reg_read(mswi_state_t *mswi,
 
     /* Address range for msip: 0x4400000 ~ 0x4404000 */
     if (addr < 0x4000) {
+        if ((addr >> 2) >= mswi->n_hart)
+            return false;
         *value = mswi->msip[addr >> 2];
         return true;
     }
@@ -140,6 +146,8 @@ static bool aclint_mswi_reg_write(mswi_state_t *mswi,
                                   uint32_t value)
 {
     if (addr < 0x4000) {
+        if ((addr >> 2) >= mswi->n_hart)
+            return false;
         mswi->msip[addr >> 2] = value & 0x1; /* Only the LSB is valid */
         return true;
     }
@@ -180,12 +188,14 @@ void aclint_sswi_update_interrupts(hart_t *hart, sswi_state_t *sswi)
     }
 }
 
-static bool aclint_sswi_reg_read(__attribute__((unused)) sswi_state_t *sswi,
+static bool aclint_sswi_reg_read(sswi_state_t *sswi,
                                  uint32_t addr,
                                  uint32_t *value)
 {
     /* Address range for ssip: 0x4500000 ~ 0x4504000 */
     if (addr < 0x4000) {
+        if ((addr >> 2) >= sswi->n_hart)
+            return false;
         *value = 0; /* Upper 31 bits are zero, and LSB reads as 0 */
         return true;
     }
@@ -197,8 +207,9 @@ static bool aclint_sswi_reg_write(sswi_state_t *sswi,
                                   uint32_t value)
 {
     if (addr < 0x4000) {
+        if ((addr >> 2) >= sswi->n_hart)
+            return false;
         sswi->ssip[addr >> 2] = value & 0x1; /* Only the LSB is valid */
-
         return true;
     }
     return false;

--- a/device.h
+++ b/device.h
@@ -248,6 +248,7 @@ typedef struct {
      * https://github.com/riscv/riscv-aclint/blob/main/riscv-aclint.adoc#21-register-map
      */
     uint64_t *mtimecmp;
+    uint32_t n_hart;
     semu_timer_t mtime;
 } mtimer_state_t;
 
@@ -276,6 +277,7 @@ typedef struct {
      * https://github.com/riscv/riscv-aclint/blob/main/riscv-aclint.adoc#31-register-map
      */
     uint32_t *msip;
+    uint32_t n_hart;
 } mswi_state_t;
 
 void aclint_mswi_update_interrupts(hart_t *hart, mswi_state_t *mswi);
@@ -303,6 +305,7 @@ typedef struct {
      * https://github.com/riscv/riscv-aclint/blob/main/riscv-aclint.adoc#41-register-map
      */
     uint32_t *ssip;
+    uint32_t n_hart;
 } sswi_state_t;
 
 void aclint_sswi_update_interrupts(hart_t *hart, sswi_state_t *sswi);

--- a/main.c
+++ b/main.c
@@ -396,6 +396,8 @@ static inline sbi_ret_t handle_sbi_ecall_HSM(hart_t *hart, int32_t fid)
     switch (fid) {
     case SBI_HSM__HART_START:
         hartid = hart->x_regs[RV_R_A0];
+        if (hartid >= vm->n_hart)
+            return (sbi_ret_t) {SBI_ERR_INVALID_PARAM, 0};
         start_addr = hart->x_regs[RV_R_A1];
         opaque = hart->x_regs[RV_R_A2];
         vm->hart[hartid]->hsm_status = SBI_HSM_STATE_STARTED;
@@ -411,6 +413,8 @@ static inline sbi_ret_t handle_sbi_ecall_HSM(hart_t *hart, int32_t fid)
         return (sbi_ret_t) {SBI_SUCCESS, 0};
     case SBI_HSM__HART_GET_STATUS:
         hartid = hart->x_regs[RV_R_A0];
+        if (hartid >= vm->n_hart)
+            return (sbi_ret_t) {SBI_ERR_INVALID_PARAM, 0};
         return (sbi_ret_t) {SBI_SUCCESS, vm->hart[hartid]->hsm_status};
     case SBI_HSM__HART_SUSPEND:
         suspend_type = hart->x_regs[RV_R_A0];
@@ -825,8 +829,11 @@ static int semu_init(emu_state_t *emu, int argc, char **argv)
     /* Set up ACLINT */
     semu_timer_init(&emu->mtimer.mtime, CLOCK_FREQ, hart_count);
     emu->mtimer.mtimecmp = calloc(vm->n_hart, sizeof(uint64_t));
+    emu->mtimer.n_hart = vm->n_hart;
     emu->mswi.msip = calloc(vm->n_hart, sizeof(uint32_t));
+    emu->mswi.n_hart = vm->n_hart;
     emu->sswi.ssip = calloc(vm->n_hart, sizeof(uint32_t));
+    emu->sswi.n_hart = vm->n_hart;
 #if SEMU_HAS(VIRTIOSND)
     if (!virtio_snd_init(&(emu->vsnd)))
         fprintf(stderr, "No virtio-snd functioned\n");
@@ -948,15 +955,16 @@ static void hart_exec_loop(void *arg)
         }
 
         /* Execute a batch of instructions before yielding.
-         * Batch size of 64 balances throughput and responsiveness.
+         * Keep peripheral polling at the original slice cadence so I/O and
+         * external interrupt latency do not scale with the batch size.
          */
         for (int i = 0; i < 64; i += SEMU_SMP_SLICE_STEPS) {
-            for (int j = 0; j < SEMU_SMP_SLICE_STEPS; j++) {
-                int ret = semu_service_hart_step(emu, hart);
-                if (unlikely(ret)) {
-                    emu->stopped = true;
-                    goto cleanup;
-                }
+            emu_tick_peripherals(emu);
+            emu_update_timer_interrupt(hart);
+            emu_update_swi_interrupt(hart);
+            if (unlikely(semu_step_chunk(emu, hart, SEMU_SMP_SLICE_STEPS))) {
+                emu->stopped = true;
+                goto cleanup;
             }
         }
 

--- a/netdev.h
+++ b/netdev.h
@@ -3,6 +3,7 @@
 #include <poll.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <sys/socket.h>
 #include <sys/uio.h>
 #include <unistd.h>
 
@@ -73,6 +74,7 @@ void net_vmnet_cleanup(net_vmnet_state_t *state);
 
 /* SLIRP (cross-platform userspace network) */
 #define SLIRP_POLL_INTERVAL 100000
+#define SLIRP_PKT_MAX 16384
 #define SLIRP_READ_SIDE 0
 #define SLIRP_WRITE_SIDE 1
 typedef struct {

--- a/plic.c
+++ b/plic.c
@@ -35,6 +35,8 @@ static bool plic_reg_read(plic_state_t *plic, uint32_t addr, uint32_t *value)
     int addr_mask = MASK(ilog2(addr)) ^ (1 & addr);
     int context = (addr_mask & addr);
     context >>= __builtin_ffs(context) - (__builtin_ffs(context) & 1);
+    if (context < 0 || context >= (int) ARRAY_SIZE(plic->ie))
+        return false;
     switch (addr & ~addr_mask) {
     case 0x800:
         *value = plic->ie[context];
@@ -66,6 +68,8 @@ static bool plic_reg_write(plic_state_t *plic, uint32_t addr, uint32_t value)
     int addr_mask = MASK(ilog2(addr)) ^ (1 & addr);
     int context = (addr_mask & addr);
     context >>= __builtin_ffs(context) - (__builtin_ffs(context) & 1);
+    if (context < 0 || context >= (int) ARRAY_SIZE(plic->ie))
+        return false;
     switch (addr & ~addr_mask) {
     case 0x800:
         value &= ~1;

--- a/slirp.c
+++ b/slirp.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 
 #include "netdev.h"
 
@@ -158,9 +159,9 @@ int semu_slirp_add_poll_socket(slirp_os_socket fd, int events, void *opaque)
 
 int net_slirp_read(net_user_options_t *usr)
 {
-    uint8_t pkt[1514];
+    uint8_t pkt[SLIRP_PKT_MAX];
     ssize_t plen =
-        read(usr->host_to_guest_channel[SLIRP_READ_SIDE], pkt, sizeof(pkt));
+        recv(usr->host_to_guest_channel[SLIRP_READ_SIDE], pkt, sizeof(pkt), 0);
     if (plen < 0) {
         if (errno == EAGAIN || errno == EWOULDBLOCK)
             return 0;
@@ -213,14 +214,18 @@ int net_slirp_init(net_user_options_t *usr)
         fprintf(stderr, "create slirp failed\n");
     }
 
-    if (pipe(usr->guest_to_host_channel) < 0)
+    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, usr->guest_to_host_channel) < 0)
         return -1;
     assert(
         fcntl(usr->guest_to_host_channel[SLIRP_READ_SIDE], F_SETFL,
               fcntl(usr->guest_to_host_channel[SLIRP_READ_SIDE], F_GETFL, 0) |
                   O_NONBLOCK) >= 0);
+    assert(
+        fcntl(usr->guest_to_host_channel[SLIRP_WRITE_SIDE], F_SETFL,
+              fcntl(usr->guest_to_host_channel[SLIRP_WRITE_SIDE], F_GETFL, 0) |
+                  O_NONBLOCK) >= 0);
 
-    if (pipe(usr->host_to_guest_channel) < 0)
+    if (socketpair(AF_UNIX, SOCK_DGRAM, 0, usr->host_to_guest_channel) < 0)
         return -1;
     assert(
         fcntl(usr->host_to_guest_channel[SLIRP_READ_SIDE], F_SETFL,

--- a/virtio-blk.c
+++ b/virtio-blk.c
@@ -140,10 +140,13 @@ static int virtio_blk_desc_handler(virtio_blk_state_t *vblk,
 
     /* Collect the descriptors */
     for (int i = 0; i < 3; i++) {
+        if (desc_idx >= queue->QueueNum) {
+            virtio_blk_set_fail(vblk);
+            return -1;
+        }
         /* The size of the `struct virtq_desc` is 4 words */
         const struct virtq_desc *desc =
             (struct virtq_desc *) &vblk->ram[queue->QueueDesc + desc_idx * 4];
-
 
         /* Retrieve the fields of current descriptor */
         vq_desc[i].addr = desc->addr;
@@ -171,8 +174,10 @@ static int virtio_blk_desc_handler(virtio_blk_state_t *vblk,
     uint64_t sector = header->sector;
     uint8_t *status = (uint8_t *) ((uintptr_t) vblk->ram + vq_desc[2].addr);
 
-    /* Check sector index is valid */
-    if (sector > (PRIV(vblk)->capacity - 1)) {
+    /* Check sector index and data length are valid */
+    uint64_t disk_size = (uint64_t) PRIV(vblk)->capacity * DISK_BLK_SIZE;
+    uint64_t offset = sector * DISK_BLK_SIZE;
+    if (sector >= PRIV(vblk)->capacity || vq_desc[1].len > disk_size - offset) {
         *status = VIRTIO_BLK_S_IOERR;
         return -1;
     }

--- a/virtio-fs.c
+++ b/virtio-fs.c
@@ -307,11 +307,9 @@ static void virtio_fs_readdirplus_handler(virtio_fs_state_t *vfs,
         size_t dirent_size = sizeof(struct fuse_direntplus) + name_len;
         size_t dirent_aligned = (dirent_size + 7) & ~7;
         offset += sizeof(struct fuse_entry_out) + dirent_aligned;
-        printf("%s      ", entry->d_name);
 
         free(full_path);
     }
-    printf("\n");
 
     struct vfs_resp_header *header_resp =
         (struct vfs_resp_header *) ((uintptr_t) vfs->ram + vq_desc[2].addr);
@@ -480,7 +478,8 @@ static void virtio_fs_open_handler(virtio_fs_state_t *vfs,
             (struct vfs_resp_header *) ((uintptr_t) vfs->ram + vq_desc[2].addr);
         header_resp->out.error = -errno;
         *plen = sizeof(struct fuse_out_header);
-        printf("[OPEN] failed: %s, error=%s\n", target_path, strerror(errno));
+        fprintf(stderr, "[OPEN] failed: %s, error=%s\n", target_path,
+                strerror(errno));
         return;
     }
 

--- a/virtio-net.c
+++ b/virtio-net.c
@@ -229,19 +229,8 @@ static ssize_t handle_write(netdev_t *netdev,
 #endif
     case _(user): {
         net_user_options_t *usr = (net_user_options_t *) netdev->op;
-
-        uint8_t pkt[1514];
-
-        /* Aggregate data from scatter-gater I/O vector into a
-         * contiguous packet buffer
-         */
-        for (size_t i = 0; i < niovs; i++) {
-            memcpy(pkt + plen, iovs_cursor[i].iov_base, iovs_cursor[i].iov_len);
-            plen += iovs_cursor[i].iov_len;
-        }
-
-        ssize_t written =
-            write(usr->host_to_guest_channel[SLIRP_WRITE_SIDE], pkt, plen);
+        ssize_t written = writev(usr->host_to_guest_channel[SLIRP_WRITE_SIDE],
+                                 iovs_cursor, niovs);
         if (written < 0) {
             queue->fd_ready = false;
             return -1;

--- a/virtio-rng.c
+++ b/virtio-rng.c
@@ -68,6 +68,8 @@ static void virtio_queue_notify_handler(virtio_rng_state_t *vrng,
     void *entropy_buf =
         (void *) ((uintptr_t) vrng->ram + (uintptr_t) vq_desc->addr);
     ssize_t total = read(rng_fd, entropy_buf, vq_desc->len);
+    if (total < 0)
+        total = 0;
 
     /* Clear write flag */
     vq_desc->flags = 0;

--- a/virtio-snd.c
+++ b/virtio-snd.c
@@ -589,7 +589,7 @@ static void virtio_snd_read_chmap_info_handler(
         props->c.channels = 1;
         props->c.positions[0] = VIRTIO_SND_CHMAP_MONO;
     }
-    *plen = cnt * sizeof(info);
+    *plen = cnt * sizeof(*info);
 }
 
 static void virtio_snd_read_pcm_set_params(
@@ -1166,8 +1166,10 @@ static bool virtio_snd_reg_write(virtio_snd_state_t *vsnd,
                 virtio_queue_notify_handler(vsnd, value);
                 break;
             case VSND_QUEUE_TX:
+                pthread_mutex_lock(&virtio_snd_mutex);
                 tx_ev_notify++;
                 pthread_cond_signal(&virtio_snd_tx_cond);
+                pthread_mutex_unlock(&virtio_snd_mutex);
                 break;
             default:
                 fprintf(stderr, "value %d not supported\n", value);


### PR DESCRIPTION
Guest-supplied values (hart IDs, VirtIO descriptor indices, MMIO register addresses) were used as array indices or memory offsets without bounds validation, allowing a malicious guest to read/write host memory.

Security fixes:
- SBI HSM: validate hartid < n_hart before indexing vm->hart[]
- VirtIO-blk: validate desc_idx < QueueNum in descriptor chain walk; overflow-safe sector+length check against disk capacity
- VirtIO-net: replace stack buffer copy with writev() for SLIRP TX, upgrade pipe to SOCK_DGRAM socketpair for message framing
- VirtIO-rng: clamp read() error return to 0
- PLIC: validate context index < ARRAY_SIZE(ie) after address decode
- ACLINT: add n_hart to state structs, validate mtimecmp/msip/ssip array indices against it

Performance:
- SMP hart_exec_loop: call semu_step_chunk(SEMU_SMP_SLICE_STEPS) instead of semu_service_hart_step(steps=1), keeping execution inside the computed-goto fast path while preserving peripheral polling cadence

Correctness:
- VirtIO-snd: fix sizeof(info) -> sizeof(*info) in chmap handler; protect tx_ev_notify with mutex to eliminate data race
- VirtIO-fs: remove debug printf from readdirplus, use stderr for error messages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened guest-facing paths across SBI HSM, PLIC, ACLINT, and `VirtIO` to block out-of-bounds accesses, plus a small SMP execution speedup and correctness fixes.

- **Bug Fixes**
  - SBI HSM and ACLINT: validate hart IDs and add `n_hart` to ACLINT state; bound-check `mtimecmp`/`msip`/`ssip` accesses.
  - PLIC: validate decoded context index against `ie` array size.
  - `virtio-blk`: bound-check descriptor indices; use overflow-safe sector+length check against disk capacity.
  - `virtio-net` (SLIRP): send with `writev()`; switch pipes to `socketpair(AF_UNIX, SOCK_DGRAM)` for message framing; use `recv()` and cap reads to `SLIRP_PKT_MAX`.
  - `virtio-rng`: clamp negative `read()` results to 0.
  - Misc: `virtio-snd` fixes `sizeof(*info)` and protects `tx_ev_notify` with a mutex; `virtio-fs` removes noisy prints and logs errors to stderr.

- **Performance**
  - SMP loop now calls `semu_step_chunk(SEMU_SMP_SLICE_STEPS)` per slice, keeping the computed-goto fast path while preserving peripheral polling cadence.

<sup>Written for commit 18a3dcb09fc069f1c8f2967a18b069e5eed5a4da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

