### PR TITLE
Drop restore-keys fallback for download cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,6 @@ jobs:
           Image
           rootfs.cpio
         key: external-${{ hashFiles('mk/external.mk') }}
-        restore-keys: |
-          external-
     - name: cache submodule builds
       uses: actions/cache@v4
       with:
@@ -91,8 +89,6 @@ jobs:
           Image
           rootfs.cpio
         key: external-${{ hashFiles('mk/external.mk') }}
-        restore-keys: |
-          external-
     - name: cache submodule builds
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
The restore-keys prefix match lets actions/cache restore stale Image and rootfs.cpio from a previous run when checksums change. Because the Makefile download recipe is target-existence-gated, stale files are never re-downloaded and the SHA1 check is never reached.

Remove restore-keys from both Linux and macOS external download cache steps. Submodule and apt caches keep their fallbacks since incremental restores are safe there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `restore-keys` from the external download cache in CI on Linux and macOS to prevent restoring stale `Image` and `rootfs.cpio` when checksums change. This forces fresh downloads and SHA1 verification; submodule and `apt` caches keep their fallbacks.

<sup>Written for commit d1392767079b9e4b505ac1ed739dc9acfa9e732e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

