### PR TITLE
Delay AMO rd write until store succeeds

### DIFF
--- a/riscv.c
+++ b/riscv.c
@@ -1399,16 +1399,17 @@ static void op_jump_link(hart_t *vm, uint8_t rd, uint32_t addr)
     }
 }
 
-#define AMO_OP(STORED_EXPR)                                   \
-    do {                                                      \
-        value2 = vm->x_regs[decoded_rs2(decoded)];            \
-        mmu_load(vm, addr, RV_MEM_LW, &value, false);         \
-        if (vm->error)                                        \
-            return;                                           \
-        set_dest_idx(vm, decoded_rd(decoded), value);         \
-        mmu_store(vm, addr, RV_MEM_SW, (STORED_EXPR), false); \
-        if (vm->error)                                        \
-            return;                                           \
+#define AMO_OP(STORED_EXPR)                            \
+    do {                                               \
+        value2 = vm->x_regs[decoded_rs2(decoded)];     \
+        mmu_load(vm, addr, RV_MEM_LW, &value, false);  \
+        if (vm->error)                                 \
+            return;                                    \
+        uint32_t stored = (STORED_EXPR);               \
+        mmu_store(vm, addr, RV_MEM_SW, stored, false); \
+        if (vm->error)                                 \
+            return;                                    \
+        set_dest_idx(vm, decoded_rd(decoded), value);  \
     } while (0)
 
 static void op_amo(hart_t *vm, const decoded_insn_t *decoded)


### PR DESCRIPTION
## Overview

Do not commit the AMO destination register before the store succeeds.

`AMO_OP` wrote `rd` before confirming that `mmu_store()` succeeded. If the store raised a fault, such as a COW/page fault, the destination register could be committed even though the guest kernel would handle the fault and retry the same instruction. 

This patch delays the `rd` write until after `mmu_store()` returns and `vm->error` is known to be clear.

## Problem Statement

Guest GDB can hang for:

```sh
gdb -q -batch -ex "set debuginfod enabled off" -ex run --args /bin/true
```

AI-agent investigation reduced the hang to GDB's default **worker-thread** path and identified that glibc's **malloc** at fork unlock path was failing to release its lock:

```asm
amoswap.w.rl a5,a5,(a4)
```

At that point, `a4` points at glibc malloc's `list_lock`, `a5` is the value to store (`0`, meaning unlocked), and the current lock value is `1` (locked). The instruction swaps the value in `a5` into the lock and returns the old lock value back in `a5`.

```text
before: list_lock = 1, a5 = 0
```

On the broken path, single-stepping showed that `a5` still receives the old lock value, but the store did not clear the lock:

```text
broken after: list_lock = 1, a5 = 1
(normal after: list_lock = 0, a5 = 1)
```

The underlying issue is the AMO implementation:

```c
#define AMO_OP(STORED_EXPR)                                   \
...
set_dest_idx(vm, decoded_rd(decoded), value);
mmu_store(vm, addr, RV_MEM_SW, (STORED_EXPR), false);
if (vm->error)
    return;
...
```

`mmu_store()` can fault, for example on a COW/page fault after `fork()`.  Therefore, the old implementation can corrupt that register before the fault is handled

## Fix

Compute the store value first, perform the store, check for an error, and only then commit `rd`:

```c
uint32_t stored = (STORED_EXPR);
mmu_store(vm, addr, RV_MEM_SW, stored, false);
if (vm->error)
    return;
set_dest_idx(vm, decoded_rd(decoded), value);
```

## Testing

`scripts/buildroot-enable-gdb.sh` is a testing helper that appends the target GDB options needed to Buildroot config.

```
#!/usr/bin/env bash
set -euo pipefail

CONFIG_FILE="${1:-configs/buildroot.config}"

cat >>"$CONFIG_FILE" <<'EOF'

# Target-side GDB reproduction support.
BR2_TOOLCHAIN_BUILDROOT_CXX=y
BR2_INSTALL_LIBSTDCPP=y
BR2_ENABLE_DEBUG=y
# BR2_STRIP_strip is not set
BR2_PACKAGE_GDB=y
BR2_PACKAGE_GDB_DEBUGGER=y
BR2_PACKAGE_GDB_SERVER=y
BR2_PACKAGE_HOST_GDB=y
EOF

echo "Appended target-side GDB reproduction options to $CONFIG_FILE"
```

Build a GDB-enabled guest:

```sh
chmod +x ./scripts/buildroot-enable-gdb.sh
./scripts/buildroot-enable-gdb.sh
./scripts/build-image.sh --all --no-ext4
./scripts/rootfs_ext4.sh rootfs.cpio ext4.img 256
make semu -j$(nproc)
```

Boot:

```sh
./semu -k Image -c 1 -b minimal.dtb -H -d ext4.img
```

Inside the guest:

```sh
gdb -q -batch -ex "set debuginfod enabled off" -ex run --args /bin/true
echo GDB_TRUE_EXIT:$?
```

Expected behavior:

**Before this patch:** hangs
**After this patch:**  exits normally with GDB_TRUE_EXIT:0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delay the AMO destination register write until after `mmu_store()` succeeds to prevent committing `rd` on a fault. Fixes a guest GDB hang triggered by `amoswap.w.rl` in glibc’s malloc lock path.

- **Bug Fixes**
  - In `AMO_OP`, compute the store value, call `mmu_store`, check `vm->error`, then write `rd`.
  - Prevents `rd` corruption on COW/page faults, restoring correct swap semantics and normal GDB exit.

<sup>Written for commit deadf03299345875bd6f85ca09ac948e28df0f9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/semu/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

